### PR TITLE
openssl_verify() call in JWT.php for SHA256 consistent

### DIFF
--- a/src/OAuth2/Encryption/Jwt.php
+++ b/src/OAuth2/Encryption/Jwt.php
@@ -80,7 +80,7 @@ class Jwt implements EncryptionInterface
                 );
 
             case 'RS256':
-                return openssl_verify($input, $signature, $key, defined('OPENSSL_ALGO_SHA256') ? OPENSSL_ALGO_SHA256 : 'sha256')  === 1;
+                return @openssl_verify($input, $signature, $key, defined('OPENSSL_ALGO_SHA256') ? OPENSSL_ALGO_SHA256 : 'sha256')  === 1;
 
             case 'RS384':
                 return @openssl_verify($input, $signature, $key, defined('OPENSSL_ALGO_SHA384') ? OPENSSL_ALGO_SHA384 : 'sha384') === 1;


### PR DESCRIPTION
The calls to openssl_verify() when using SHA256 encryption were set to raise errors, whilst sha384 and sha512 they were suppressed. This patch makes them consistent.
